### PR TITLE
chore: jfrog cli use WithFile set Permission 

### DIFF
--- a/jfrogcli/main.go
+++ b/jfrogcli/main.go
@@ -91,8 +91,9 @@ func (c *Jfrogcli) Install(
 	binFile := dag.HTTP(binURL)
 
 	ctr = ctr.
-		WithMountedFile("/usr/local/bin/jf", binFile).
-		WithExec([]string{"chmod", "+x", "/usr/local/bin/jf"}).
+		WithMountedFile("/usr/local/bin/jf", binFile, dagger.ContainerWithFileOpts{
+			Permissions: 555,
+		}).
 		WithEnvVariable("PATH", "/usr/local/bin:$PATH", dagger.ContainerWithEnvVariableOpts{Expand: true}).
 		WithEnvVariable("CI", "true").
 		WithEnvVariable("JFROG_CLI_REPORT_USAGE", "false").


### PR DESCRIPTION
According to this [recipe](https://docs.dagger.io/cookbook#request-a-file-over-httphttps-and-save-it-in-a-container) use WithFile instead of WithMountedFile and make jf binary executable with permission instead of chmod +x.

chmod +x can lead to error when the user container has no root access.